### PR TITLE
Add a filter for user (aka the person that opened the issue)

### DIFF
--- a/src/github/issues.py
+++ b/src/github/issues.py
@@ -178,7 +178,7 @@ class Commands(object):
             printer.write("\n".join(lines))
         printer.close()
 
-    def list(self, state='open', verbose=False, webbrowser=False, **kwargs):
+    def list(self, state='open', verbose=False, webbrowser=False, created_by=False, **kwargs):
         if webbrowser:
             issues_url_template = "https://github.com/%s/%s/issues/%s"
             if state == "closed":
@@ -205,8 +205,9 @@ class Commands(object):
             issues = get_key(result, 'issues')
             if issues:
                 for issue in issues:
-                    lines = format_issue(issue, verbose)
-                    printer.write("\n".join(lines))
+                    if created_by == False or created_by == issue.get('user'):
+                        lines = format_issue(issue, verbose)
+                        printer.write("\n".join(lines))
             else:
                 printer.write("no %s issues available" % st)
             if not st == states[-1]:
@@ -333,6 +334,8 @@ Examples:
 %prog -v                              same as: %prog list -v
 %prog [-s o|c] -w                     show issues' GitHub page in web browser
                                     (default: open)
+%prog list -u <github_user>         show issues created by specified user
+
 %prog show <nr>                       show issue <nr>
 %prog show <nr> -v                    same as above, but with comments
 %prog <nr>                            same as: %prog show <nr>
@@ -372,6 +375,8 @@ command-line interface to GitHub's Issues API (v2)"""
         default='open', help="specify state (only for list and search "\
         "(except `all`) commands) choices are: open (o), closed (c), all "\
         "(a) [default: open]")
+    parser.add_option("-u", "--user", action="store", dest="created_by", default=False,\
+        help="issues created by <github_username> [default: all]")
     parser.add_option("-m", "--message", action="store", dest="message",
       default=None, help="message content for opening or commenting on an "\
         "issue without using the editor")

--- a/tests/test_issues_cli.py
+++ b/tests/test_issues_cli.py
@@ -7,7 +7,6 @@ from github.issues import main
 repo = 'jsmits/github-cli-public-test'
 prog = 'ghi'
 
-
 def test_commands():
     for cmd, exp in test_input:
         def check_command(cmd, exp):
@@ -32,6 +31,7 @@ test_input = (
     ('list -s open', None), ('list -s o', None), ('list -s closed', None),
     ('list -s c', None), ('list -s all', None), ('list -s a', None),
     ('-s a', None), ('-s a -v', None), ('list -s close', SystemExit),
+    ('list -u bobdole', None),
 
     # show commands
     ('show 1', None), ('1', None), ('17288182', "error: server problem (HTTP"\


### PR DESCRIPTION
Hey great stuff on this project. Very useful. I just needed one tiny feature, filtering by the user who created an issue.

usage:

```
ghi list -s close -u jsmits
ghi list -s open -u gregory80
ghi list -u <gh_user> 
```

adds a -u option to allow filtering by created_by user. something handy for shared repos. especially github teams where this seems to be deficient. Matches the user attribute of the github isssues list response items. usage <code>ghi -u jsmits</code> for issues created by jsmits

btw, I don't have much experience with nose.tools I ran the tests and test appeared to pass, but even sending error values to the test suite didnt appear to trigger errors. So not 100% on the testing suite. I was able to build and run the app as expected.

thanks
-gregory
